### PR TITLE
Pass client ID to backend

### DIFF
--- a/__tests__/KoskiClientTest.js
+++ b/__tests__/KoskiClientTest.js
@@ -56,6 +56,8 @@ describe('KoskiClient', () => {
 
     it('Should be able to get opinto-oikeudet', async() => {
         const oid = 123;
+        const clientMemberCode = '123456789-0';
+
         const opiskeluoikeudet = {
             oppilaitokset: ['mallikoulu'],
         };
@@ -69,8 +71,8 @@ describe('KoskiClient', () => {
         koskiClient.instance = axios;
         spyOn(axios, 'get').and.callThrough();
 
-        const response = await koskiClient.getOpintoOikeudet(oid);
+        const response = await koskiClient.getOpintoOikeudet(oid, clientMemberCode);
         expect(response.opiskeluoikeudet).toEqual(opiskeluoikeudet);
-        expect(koskiClient.instance.get).toHaveBeenCalledWith(`oppija/${oid}`);
+        expect(koskiClient.instance.get).toHaveBeenCalledWith(`oppija/${oid}`, { headers: { 'X-ROAD-MEMBER': clientMemberCode }});
     });
 });

--- a/__tests__/LambdaTest.js
+++ b/__tests__/LambdaTest.js
@@ -50,6 +50,7 @@ describe('Lambda', () => {
     it('Can parse SOAP POST payload', async(done) => {
         const oid = 123;
         const hetu = '010190-012A';
+        const clientMemberCode = '123456789-0';
         const mockSoapEnvelope = '<xml><response>opinto-oikeudet</response></xml>';
         const event = {
             httpMethod: 'POST',
@@ -64,7 +65,7 @@ describe('Lambda', () => {
         spyOn(lambda.secretsManager, 'getKoskiCredentials').and.returnValue(() => {
             Promise.resolve({ username: 'u', password: 'p' }); // our mock client doesn't actually make http requests
         });
-        spyOn(lambda.parser, 'parsePayload').and.returnValue({ hetu });
+        spyOn(lambda.parser, 'parsePayload').and.returnValue({ hetu, clientMemberCode });
         lambda.client = { getUserOid: () => {}, getOpintoOikeudet: () => {} }; // cannot spy on null client
         spyOn(lambda.client, 'getUserOid').and.returnValue(oid);
         spyOn(lambda.client, 'getOpintoOikeudet').and.returnValue({ opintooikeudet: ['mallikoulu'] });
@@ -74,7 +75,7 @@ describe('Lambda', () => {
             expect(lambda.handleSOAPRequest).toHaveBeenCalled();
             // expect(lambda.secretsManager.getKoskiCredentials).toHaveBeenCalled(); // not called as we just set the client on the test!
             expect(lambda.client.getUserOid).toHaveBeenCalledWith(hetu);
-            expect(lambda.client.getOpintoOikeudet).toHaveBeenCalledWith(oid);
+            expect(lambda.client.getOpintoOikeudet).toHaveBeenCalledWith(oid, clientMemberCode);
             expect(lambda.responseBuilder.buildResponseMessage).toHaveBeenCalled();
             expect(error).toBe(null);
             expect(response).toEqual(expectedResponse);

--- a/__tests__/integration/KoskiClientTest.js
+++ b/__tests__/integration/KoskiClientTest.js
@@ -2,6 +2,8 @@ import PromiseMatcher from 'jasmine-node-promise-matchers';
 import KoskiClient from '../../src/KoskiClient';
 import SecretsManagerProvider from '../../src/SecretsManagerProvider';
 
+const clientMemberCode = '123456789-0';
+
 describe('KoskiClient', () => {
     beforeEach(() => {
         jasmine.addMatchers(PromiseMatcher);
@@ -21,7 +23,7 @@ describe('KoskiClient', () => {
 
         const client = new KoskiClient(username, password);
         const oid = await client.getUserOid('120496-949B');
-        const opintoOikeudet = await client.getOpintoOikeudet(oid);
+        const opintoOikeudet = await client.getOpintoOikeudet(oid, clientMemberCode);
 
         // Required by HSL
         expect(opintoOikeudet.henkilö.oid).toEqual('1.2.246.562.24.92333381381');
@@ -46,7 +48,7 @@ describe('KoskiClient', () => {
 
         const client = new KoskiClient(username, password);
         const oid = await client.getUserOid('080598-532M');
-        const opintoOikeudet = await client.getOpintoOikeudet(oid);
+        const opintoOikeudet = await client.getOpintoOikeudet(oid, clientMemberCode);
 
         expect(opintoOikeudet.opiskeluoikeudet[0].arvioituPäättymispäivä).toEqual('2020-05-01');
         done();
@@ -57,7 +59,7 @@ describe('KoskiClient', () => {
 
         const client = new KoskiClient(username, password);
         const oid = await client.getUserOid('080598-2684');
-        const opintoOikeudet = await client.getOpintoOikeudet(oid);
+        const opintoOikeudet = await client.getOpintoOikeudet(oid, clientMemberCode);
 
         const jakso1 = opintoOikeudet.opiskeluoikeudet[0].lisätiedot.osaAikaisuusjaksot.find(jakso => jakso.alku === '2018-05-08');
         const jakso2 = opintoOikeudet.opiskeluoikeudet[0].lisätiedot.osaAikaisuusjaksot.find(jakso => jakso.alku === '2019-05-08');

--- a/src/KoskiClient.js
+++ b/src/KoskiClient.js
@@ -65,11 +65,13 @@ class KoskiClient {
         });
     }
 
-    getOpintoOikeudet(oid) {
+    getOpintoOikeudet(oid, clientMemberCode) {
+        if (!clientMemberCode) throw new ClientError('clientMemberCode must be defined when requesting opinto-oikeudet');
+
         return new Promise(async(resolve, reject) => {
             try {
                 log.info(`Getting opinto-oikeudet for student ${oid}`);
-                const response = await this.instance.get(`oppija/${oid}`);
+                const response = await this.instance.get(`oppija/${oid}`, { headers: { 'X-ROAD-MEMBER': clientMemberCode }});
                 const { henkilö, opiskeluoikeudet } = response.data;
 
                 if (typeof opiskeluoikeudet === 'undefined' || opiskeluoikeudet === null) reject(new Error('No opiskeluoikeudet found'));

--- a/src/Lambda.js
+++ b/src/Lambda.js
@@ -53,7 +53,7 @@ class Lambda {
                 } = this.parser.parsePayload(xml);
 
                 const oid = await this.client.getUserOid(hetu);
-                const opintoOikeudet = await this.client.getOpintoOikeudet(oid);
+                const opintoOikeudet = await this.client.getOpintoOikeudet(oid, clientMemberCode);
 
                 const soapEnvelope = this.responseBuilder.buildResponseMessage(
                     clientXRoadInstance, clientMemberClass, clientMemberCode, clientSubsystemCode,


### PR DESCRIPTION
Pass client ID to backend API so it knows whether the request can be served or not (i.e. has the client been authorized)