### PR TITLE
Support issue soap header

### DIFF
--- a/__tests__/KoskiClientTest.js
+++ b/__tests__/KoskiClientTest.js
@@ -56,6 +56,8 @@ describe('KoskiClient', () => {
 
     it('Should be able to get opinto-oikeudet', async() => {
         const oid = 123;
+        const clientMemberCode = '123456789-0';
+
         const opiskeluoikeudet = {
             oppilaitokset: ['mallikoulu'],
         };
@@ -69,8 +71,8 @@ describe('KoskiClient', () => {
         koskiClient.instance = axios;
         spyOn(axios, 'get').and.callThrough();
 
-        const response = await koskiClient.getOpintoOikeudet(oid);
+        const response = await koskiClient.getOpintoOikeudet(oid, clientMemberCode);
         expect(response.opiskeluoikeudet).toEqual(opiskeluoikeudet);
-        expect(koskiClient.instance.get).toHaveBeenCalledWith(`oppija/${oid}`);
+        expect(koskiClient.instance.get).toHaveBeenCalledWith(`oppija/${oid}`, { headers: { 'X-ROAD-MEMBER': clientMemberCode }});
     });
 });

--- a/__tests__/LambdaTest.js
+++ b/__tests__/LambdaTest.js
@@ -50,6 +50,7 @@ describe('Lambda', () => {
     it('Can parse SOAP POST payload', async(done) => {
         const oid = 123;
         const hetu = '010190-012A';
+        const clientMemberCode = '123456789-0';
         const mockSoapEnvelope = '<xml><response>opinto-oikeudet</response></xml>';
         const event = {
             httpMethod: 'POST',
@@ -64,7 +65,7 @@ describe('Lambda', () => {
         spyOn(lambda.secretsManager, 'getKoskiCredentials').and.returnValue(() => {
             Promise.resolve({ username: 'u', password: 'p' }); // our mock client doesn't actually make http requests
         });
-        spyOn(lambda.parser, 'parsePayload').and.returnValue({ hetu });
+        spyOn(lambda.parser, 'parsePayload').and.returnValue({ hetu, clientMemberCode });
         lambda.client = { getUserOid: () => {}, getOpintoOikeudet: () => {} }; // cannot spy on null client
         spyOn(lambda.client, 'getUserOid').and.returnValue(oid);
         spyOn(lambda.client, 'getOpintoOikeudet').and.returnValue({ opintooikeudet: ['mallikoulu'] });
@@ -74,7 +75,7 @@ describe('Lambda', () => {
             expect(lambda.handleSOAPRequest).toHaveBeenCalled();
             // expect(lambda.secretsManager.getKoskiCredentials).toHaveBeenCalled(); // not called as we just set the client on the test!
             expect(lambda.client.getUserOid).toHaveBeenCalledWith(hetu);
-            expect(lambda.client.getOpintoOikeudet).toHaveBeenCalledWith(oid);
+            expect(lambda.client.getOpintoOikeudet).toHaveBeenCalledWith(oid, clientMemberCode);
             expect(lambda.responseBuilder.buildResponseMessage).toHaveBeenCalled();
             expect(error).toBe(null);
             expect(response).toEqual(expectedResponse);

--- a/__tests__/integration/KoskiClientTest.js
+++ b/__tests__/integration/KoskiClientTest.js
@@ -2,6 +2,8 @@ import PromiseMatcher from 'jasmine-node-promise-matchers';
 import KoskiClient from '../../src/KoskiClient';
 import SecretsManagerProvider from '../../src/SecretsManagerProvider';
 
+const clientMemberCode = '123456789-0';
+
 describe('KoskiClient', () => {
     beforeEach(() => {
         jasmine.addMatchers(PromiseMatcher);
@@ -21,7 +23,7 @@ describe('KoskiClient', () => {
 
         const client = new KoskiClient(username, password);
         const oid = await client.getUserOid('120496-949B');
-        const opintoOikeudet = await client.getOpintoOikeudet(oid);
+        const opintoOikeudet = await client.getOpintoOikeudet(oid, clientMemberCode);
 
         // Required by HSL
         expect(opintoOikeudet.henkilö.oid).toEqual('1.2.246.562.24.92333381381');
@@ -46,7 +48,7 @@ describe('KoskiClient', () => {
 
         const client = new KoskiClient(username, password);
         const oid = await client.getUserOid('080598-532M');
-        const opintoOikeudet = await client.getOpintoOikeudet(oid);
+        const opintoOikeudet = await client.getOpintoOikeudet(oid, clientMemberCode);
 
         expect(opintoOikeudet.opiskeluoikeudet[0].arvioituPäättymispäivä).toEqual('2020-05-01');
         done();
@@ -57,7 +59,7 @@ describe('KoskiClient', () => {
 
         const client = new KoskiClient(username, password);
         const oid = await client.getUserOid('080598-2684');
-        const opintoOikeudet = await client.getOpintoOikeudet(oid);
+        const opintoOikeudet = await client.getOpintoOikeudet(oid, clientMemberCode);
 
         const jakso1 = opintoOikeudet.opiskeluoikeudet[0].lisätiedot.osaAikaisuusjaksot.find(jakso => jakso.alku === '2018-05-08');
         const jakso2 = opintoOikeudet.opiskeluoikeudet[0].lisätiedot.osaAikaisuusjaksot.find(jakso => jakso.alku === '2019-05-08');

--- a/__tests__/soap/SoapRequestPayloadParserTest.js
+++ b/__tests__/soap/SoapRequestPayloadParserTest.js
@@ -23,6 +23,7 @@ describe('SoapRequestPayloadParser', () => {
                 clientUserId: '123456789',
                 clientRequestId: 'ID123456',
                 clientType: 'SUBSYSTEM',
+                clientIssue: 'issue #123',
                 hetu: '210947-613P',
             };
 

--- a/__tests__/soap/SoapResponseMessageBuilderTest.js
+++ b/__tests__/soap/SoapResponseMessageBuilderTest.js
@@ -14,7 +14,7 @@ describe('SoapResponseMessageBuilder', () => {
         const expectedResponse = parser.parseFromString(fs.readFileSync('examples/opintooikeudet-response.xml', 'UTF-8'));
         const createdXML = parser.parseFromString(responseBuilder.buildResponseMessage(
             'FI-DEV', 'GOV', '2769790-1', 'koski', '123456789',
-            'ID123456', 'SUBSYSTEM', opintoOikeudet,
+            'ID123456', 'SUBSYSTEM', 'issue #123', opintoOikeudet,
         ));
         const result = compare(expectedResponse, createdXML, { stripSpaces: true });
 

--- a/examples/opintooikeudet-payload.xml
+++ b/examples/opintooikeudet-payload.xml
@@ -1,7 +1,7 @@
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xro="http://x-road.eu/xsd/xroad.xsd" xmlns:id="http://x-road.eu/xsd/identifiers" xmlns:prod="http://docs.koski-xroad.fi/producer">
    <soapenv:Header>
       <xro:protocolVersion>4.0</xro:protocolVersion>
-      <!-- <xro:issue>?</xro:issue> -->
+      <xro:issue>issue #123</xro:issue>
       <xro:id>ID123456</xro:id>
       <xro:userId>123456789</xro:userId>
       <xro:service id:objectType="SERVICE">

--- a/examples/opintooikeudet-response.xml
+++ b/examples/opintooikeudet-response.xml
@@ -21,6 +21,7 @@
     <xrd:requestHash algorithmId="http://www.w3.org/2001/04/xmlenc#sha512">zOVgyoXpF59C5qXykS6DvDZzkvhAIF9ItHsuK3gU3MHWLRQ2mKp19HqJ7sZraE6b5jySrcwVL9EGIXPAck7ykg==</xrd:requestHash>
     -->
     <xrd:protocolVersion>4.0</xrd:protocolVersion>
+    <xrd:issue>issue #123</xrd:issue>
   </SOAP-ENV:Header>
   <SOAP-ENV:Body>
     <kns1:opintoOikeudetServiceResponse xmlns:kns1="http://docs.koski-xroad.fi/producer">

--- a/src/KoskiClient.js
+++ b/src/KoskiClient.js
@@ -65,11 +65,13 @@ class KoskiClient {
         });
     }
 
-    getOpintoOikeudet(oid) {
+    getOpintoOikeudet(oid, clientMemberCode) {
+        if (!clientMemberCode) throw new ClientError('clientMemberCode must be defined when requesting opinto-oikeudet');
+
         return new Promise(async(resolve, reject) => {
             try {
                 log.info(`Getting opinto-oikeudet for student ${oid}`);
-                const response = await this.instance.get(`oppija/${oid}`);
+                const response = await this.instance.get(`oppija/${oid}`, { headers: { 'X-ROAD-MEMBER': clientMemberCode }});
                 const { henkilö, opiskeluoikeudet } = response.data;
 
                 if (typeof opiskeluoikeudet === 'undefined' || opiskeluoikeudet === null) reject(new Error('No opiskeluoikeudet found'));

--- a/src/KoskiClient.js
+++ b/src/KoskiClient.js
@@ -71,7 +71,7 @@ class KoskiClient {
         return new Promise(async(resolve, reject) => {
             try {
                 log.info(`Getting opinto-oikeudet for student ${oid}`);
-                const response = await this.instance.get(`oppija/${oid}`, { headers: { 'X-ROAD-MEMBER': clientMemberCode }});
+                const response = await this.instance.get(`oppija/${oid}`, { headers: { 'X-ROAD-MEMBER': clientMemberCode } });
                 const { henkilö, opiskeluoikeudet } = response.data;
 
                 if (typeof opiskeluoikeudet === 'undefined' || opiskeluoikeudet === null) reject(new Error('No opiskeluoikeudet found'));

--- a/src/Lambda.js
+++ b/src/Lambda.js
@@ -49,6 +49,7 @@ class Lambda {
                     clientUserId,
                     clientRequestId,
                     clientType,
+                    clientIssue,
                     hetu,
                 } = this.parser.parsePayload(xml);
 
@@ -57,7 +58,7 @@ class Lambda {
 
                 const soapEnvelope = this.responseBuilder.buildResponseMessage(
                     clientXRoadInstance, clientMemberClass, clientMemberCode, clientSubsystemCode,
-                    clientUserId, clientRequestId, clientType, opintoOikeudet,
+                    clientUserId, clientRequestId, clientType, clientIssue, opintoOikeudet,
                 );
 
                 resolve(soapEnvelope);

--- a/src/Lambda.js
+++ b/src/Lambda.js
@@ -53,7 +53,7 @@ class Lambda {
                 } = this.parser.parsePayload(xml);
 
                 const oid = await this.client.getUserOid(hetu);
-                const opintoOikeudet = await this.client.getOpintoOikeudet(oid);
+                const opintoOikeudet = await this.client.getOpintoOikeudet(oid, clientMemberCode);
 
                 const soapEnvelope = this.responseBuilder.buildResponseMessage(
                     clientXRoadInstance, clientMemberClass, clientMemberCode, clientSubsystemCode,

--- a/src/soap/SoapRequestPayloadParser.js
+++ b/src/soap/SoapRequestPayloadParser.js
@@ -2,6 +2,16 @@ import { DOMParser } from 'xmldom';
 import xpath from 'xpath';
 import ClientError from '../error/ClientError';
 
+const clientXRoadInstancePath = '//soap:Header/xroad:client/id:xRoadInstance/text()';
+const clientMemberClassPath = '//soap:Header/xroad:client/id:memberClass/text()';
+const clientMemberCodePath = '//soap:Header/xroad:client/id:memberCode/text()';
+const clientSubSystemCodePath = '//soap:Header/xroad:client/id:subsystemCode/text()';
+const clientUserIdPath = '//soap:Header/xroad:userId/text()';
+const clientRequestIdPath = '//soap:Header/xroad:id/text()';
+const clientTypePath = '//soap:Header/xroad:client/@id:objectType';
+const clientIssuePath = '//soap:Header/xroad:issue/text()';
+const hetuPath = '//soap:Body/koski:opintoOikeudetService/koski:hetu/text()';
+
 class SoapRequestPayloadParser {
     constructor() {
         this.select = xpath.useNamespaces({
@@ -12,22 +22,28 @@ class SoapRequestPayloadParser {
         });
     }
 
+    nodeValue(xpath, doc) {
+        const element = this.select(xpath, doc)[0];
+        return typeof element !== 'undefined' ? element.nodeValue : undefined;
+    }
+
     parsePayload(xmlContent) {
         if (typeof xmlContent === 'undefined' || xmlContent === null) throw new ClientError('Cannot parse empty XML content');
 
         const doc = new DOMParser().parseFromString(xmlContent);
 
         return {
-            clientXRoadInstance: this.select('//soap:Header/xroad:client/id:xRoadInstance/text()', doc)[0].nodeValue,
-            clientMemberClass: this.select('//soap:Header/xroad:client/id:memberClass/text()', doc)[0].nodeValue,
-            clientMemberCode: this.select('//soap:Header/xroad:client/id:memberCode/text()', doc)[0].nodeValue,
-            clientSubsystemCode: this.select('//soap:Header/xroad:client/id:subsystemCode/text()', doc)[0].nodeValue,
+            clientXRoadInstance: this.nodeValue(clientXRoadInstancePath, doc),
+            clientMemberClass: this.nodeValue(clientMemberClassPath, doc),
+            clientMemberCode: this.nodeValue(clientMemberCodePath, doc),
+            clientSubsystemCode: this.nodeValue(clientSubSystemCodePath, doc),
 
-            clientUserId: this.select('//soap:Header/xroad:userId/text()', doc)[0].nodeValue,
-            clientRequestId: this.select('//soap:Header/xroad:id/text()', doc)[0].nodeValue,
-            clientType: this.select('//soap:Header/xroad:client/@id:objectType', doc)[0].value,
+            clientUserId: this.nodeValue(clientUserIdPath, doc),
+            clientRequestId: this.nodeValue(clientRequestIdPath, doc),
+            clientType: this.nodeValue(clientTypePath, doc),
+            clientIssue: this.nodeValue(clientIssuePath, doc),
 
-            hetu: this.select('//soap:Body/koski:opintoOikeudetService/koski:hetu/text()', doc)[0].nodeValue,
+            hetu: this.nodeValue(hetuPath, doc),
         };
     }
 }

--- a/src/soap/SoapResponseMessageBuilder.js
+++ b/src/soap/SoapResponseMessageBuilder.js
@@ -16,47 +16,48 @@ class SoapResponseMessageBuilder {
 
     buildResponseMessage(
         clientXRoadInstance, clientMemberClass, clientMemberCode, clientSubsystemCode,
-        clientUserId, clientRequestId, clientType, opintoOikeudet,
+        clientUserId, clientRequestId, clientType, clientIssue, opintoOikeudet,
     ) {
-        try {
-            return builder.create('SOAP-ENV:Envelope', {
+        try { /* eslint-disable newline-per-chained-call */
+            const envelope = builder.create('SOAP-ENV:Envelope', {
                 version: '1.0',
                 encoding: 'UTF-8',
             })
-            /* eslint-disable newline-per-chained-call */
                 .att('xmlns:SOAP-ENV', 'http://schemas.xmlsoap.org/soap/envelope/')
                 .att('xmlns:id', 'http://x-road.eu/xsd/identifiers')
-                .att('xmlns:xrd', 'http://x-road.eu/xsd/xroad.xsd')
-                .ele('SOAP-ENV:Header')
+                .att('xmlns:xrd', 'http://x-road.eu/xsd/xroad.xsd');
 
-                // TODO: Vastaussanoman on sisällettävä täsmälleen samat otsikkotiedot kuin kyselysanomassakin on.
-                .ele('xrd:client').att('id:objectType', clientType)
+            const header = envelope.ele('SOAP-ENV:Header');
+
+            header.ele('xrd:client').att('id:objectType', clientType)
                 .ele('id:xRoadInstance', clientXRoadInstance).up()
                 .ele('id:memberClass', clientMemberClass).up()
                 .ele('id:memberCode', clientMemberCode).up()
-                .ele('id:subsystemCode', clientSubsystemCode).up()
+                .ele('id:subsystemCode', clientSubsystemCode);
 
-                .up()
-                .ele('xrd:service').att('id:objectType', 'SERVICE')
+            header.ele('xrd:service').att('id:objectType', 'SERVICE')
                 .ele('id:xRoadInstance', this.serverXRoadInstance).up()
                 .ele('id:memberClass', this.serverMemberClass).up()
                 .ele('id:memberCode', this.serverMemberCode).up()
                 .ele('id:subsystemCode', this.serverSubsystemCode).up()
                 .ele('id:serviceCode', this.serverServiceCode).up()
-                .ele('id:serviceVersion', this.serverServiceVersion).up()
+                .ele('id:serviceVersion', this.serverServiceVersion);
 
-                .up()
-                .ele('xrd:userId', clientUserId).up()
+            header.ele('xrd:userId', clientUserId).up()
                 .ele('xrd:id', clientRequestId).up()
-                .ele('xrd:protocolVersion', this.serverProtocolVersion).up()
+                .ele('xrd:protocolVersion', this.serverProtocolVersion);
 
-                .up()
-                .ele('SOAP-ENV:Body')
+            if (typeof clientIssue !== 'undefined' && clientIssue !== null) {
+                header.ele('xrd:issue', clientIssue);
+            }
+
+            envelope.ele('SOAP-ENV:Body')
                 .ele(`kns1:${this.serverServiceCode}Response`).att('xmlns:kns1', 'http://docs.koski-xroad.fi/producer')
-                .ele('kns1:opintoOikeudet').dat(JSON.stringify(opintoOikeudet))
+                .ele('kns1:opintoOikeudet').dat(JSON.stringify(opintoOikeudet));
 
-                .end({ pretty: true });
             /* eslint-enable */
+
+            return envelope.end({ pretty: true });
         } catch (err) {
             log.error(err);
             throw new Error('Failed to create SOAP Envelope');


### PR DESCRIPTION
Support for SOAP header _issue_. The field is optional, but including it in requests made our SOAP responses invalid.