### PR TITLE
Use HTTP POST for hetu queries, so hetu won't get stored to logs

### DIFF
--- a/__tests__/KoskiClientTest.js
+++ b/__tests__/KoskiClientTest.js
@@ -36,18 +36,18 @@ describe('KoskiClient', () => {
     it('Should be able to get student number from koski backend', async() => {
         const userId = 123;
         const axios = {
-            get: () => new Promise((resolve) => {
+            post: () => new Promise((resolve) => {
                 resolve({ data: [{ oid: userId }] });
             }),
         };
         const koskiClient = new KoskiClient();
 
         koskiClient.instance = axios;
-        spyOn(axios, 'get').and.callThrough();
+        spyOn(axios, 'post').and.callThrough();
 
         const oid = await koskiClient.getUserOid('210947-613P');
         expect(oid).toBe(userId);
-        expect(koskiClient.instance.get).toHaveBeenCalledWith('henkilo/hetu/210947-613P');
+        expect(koskiClient.instance.post).toHaveBeenCalledWith('henkilo/hetu', { hetu: '210947-613P' });
     });
 
     it('Error messages should not contain sensitive information', () => {

--- a/src/KoskiClient.js
+++ b/src/KoskiClient.js
@@ -49,7 +49,7 @@ class KoskiClient {
         return new Promise(async(resolve, reject) => {
             try {
                 log.info('Getting student ID from Koski');
-                const response = await this.instance.get(`${config.get('backend.api.henkilö')}/${hetu}`);
+                const response = await this.instance.post(config.get('backend.api.henkilö'), { hetu });
                 const students = response.data;
 
                 if (!Array.isArray(students)) reject(new Error('Unexpected student search response from Koski backend'));


### PR DESCRIPTION
Use HTTP POST requests so that hetu won't get stored to log files