### PR TITLE
Remove references to outdated service URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ ja testaa että applikaatio toimii:
 ```
 curl -v -k -d @examples/opintooikeudet-payload.xml --header "Content-Type: text/xml" -X POST http://localhost:3000/
 ```
+
+### Huomioita WSDL-tiedostosta
+
+Applikaation tuottaman WSDL-tiedoston sisältämä `<soap:address location>` -elementti ei sisällä aitoa, toimivaa osoitetta. AWS-ympäristössä tämän lambda-funktion edustalla oleva API gateway on private-tyyppinen, ja sille on käyttöoikeus ainoastaan liityntäpalvelimilta. Siksi aitoa osoitetta ei haluta sisällyttää tähän. Aito osoite on konfiguroitu manuaalisesti liityntäpalvelimien käyttöliittymässä. Kun WSDL-tiedosto haetaan palveluväylän toimesta, osoite päivitetään joka tapauksessa erilliseksi esimerkkiosoitteeksi ennen WSDL:n julkaisua, joten tässä käytetyllä osoitteella ei ole merkitystä.

--- a/config/default.json
+++ b/config/default.json
@@ -7,12 +7,7 @@
     }
   },
   "xroad": {
-    "env": "FI-DEV",
-    "service": {
-      "port": {
-        "address": "https://sp.omadata.koski-xroad.fi"
-      }
-    }
+    "env": "FI-DEV"
   },
   "member": {
     "1516651-3": { "name": "frank" },

--- a/config/prod.json
+++ b/config/prod.json
@@ -7,12 +7,7 @@
     }
   },
   "xroad": {
-    "env": "FI",
-    "service": {
-      "port": {
-        "address": "https://sp.omadata.opintopolku.fi"
-      }
-    }
+    "env": "FI"
   },
   "member": {
     "2274586-3": { "name": "hsl" }

--- a/config/qa.json
+++ b/config/qa.json
@@ -8,12 +8,7 @@
     }
   },
   "xroad": {
-    "env": "FI-TEST",
-    "service": {
-      "port": {
-        "address": "https://sp.omadata.testiopintopolku.fi"
-      }
-    }
+    "env": "FI-TEST"
   },
   "member": {
     "1516651-3": { "name": "frank" },

--- a/config/test.json
+++ b/config/test.json
@@ -7,12 +7,7 @@
     }
   },
   "xroad": {
-    "env": "FI-DEV",
-    "service": {
-      "port": {
-        "address": "https://sp.omadata.koski-xroad.fi"
-      }
-    }
+    "env": "FI-DEV"
   },
   "member": {
     "1516651-3": { "name": "frank" },

--- a/docs/koski.wsdl
+++ b/docs/koski.wsdl
@@ -90,7 +90,7 @@
     </wsdl:binding>
     <wsdl:service name="opintoOikeudetService">
         <wsdl:port binding="tns:opintoOikeudetServiceBinding" name="opintoOikeudetServicePort">
-            <soap:address location="https://sp.omadata.koski-xroad.fi"/>
+            <soap:address location="http://localhost/to-be-replaced-with-actual-service-address"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>

--- a/src/soap/WSDLBuilder.js
+++ b/src/soap/WSDLBuilder.js
@@ -1,5 +1,4 @@
 import builder from 'xmlbuilder';
-import config from 'config';
 
 class WSDLBuilder {
     static buildOpintoOikeusWSDL() {
@@ -207,7 +206,7 @@ class WSDLBuilder {
                         '@binding': 'tns:opintoOikeudetServiceBinding',
                         '@name': 'opintoOikeudetServicePort',
                         'soap:address': {
-                            '@location': `${config.get('xroad.service.port.address')}`,
+                            '@location': 'http://localhost/to-be-replaced-with-actual-service-address',
                         },
                     },
                 },


### PR DESCRIPTION
Public API gateway in front of this lambda function has been replaced with a private API gateway.

Domain name and address of the private API gateway does not need to be kept in this repository
anymore - the API is only accessed from security servers (_liityntäpalvelin_) and the address is configured manually in security server's UI.

When WSDL is retrived by _palveluväylä_, the address is replaced with another example address before publishing. Thus, it does not matter what address value is specified here.